### PR TITLE
amends README and activities_spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,36 @@ Return JSON data in the format below:
   {
     "id": 1,
     "name": "Caitlin",
-    "age": 8
+    "age": 8,
+    "activities": [
+      {
+        "id": 1,
+        "name": "Archery",
+        "difficulty": 2
+      },
+      {
+        "id": 2,
+        "name": "Swimming",
+        "difficulty": 3
+      }
+    ]
   },
   {
     "id": 2,
     "name": "Lizzie",
-    "age": 9
+    "age": 9,
+    "activities": [
+      {
+        "id": 2,
+        "name": "Swimming",
+        "difficulty": 3
+      },
+      {
+        "id": 1,
+        "name": "Archery",
+        "difficulty": 2
+      }
+    ]
   }
 ]
 ```

--- a/spec/requests/activities_spec.rb
+++ b/spec/requests/activities_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Activities", type: :request do
       end
 
       it "deletes the associated Signups" do
-        count = Activity.first.signups.count
+        count = Activity.second.signups.count
         expect { delete "/activities/#{Activity.second.id}" }.to change(Signup, :count).by(-count)
       end
 

--- a/spec/requests/activities_spec.rb
+++ b/spec/requests/activities_spec.rb
@@ -41,12 +41,12 @@ RSpec.describe "Activities", type: :request do
     context "with a valid ID" do
 
       it "deletes the Activity" do
-        expect { delete "/activities/#{Activity.first.id}" }.to change(Activity, :count).by(-1)
+        expect { delete "/activities/#{Activity.second.id}" }.to change(Activity, :count).by(-1)
       end
 
       it "deletes the associated Signups" do
         count = Activity.first.signups.count
-        expect { delete "/activities/#{Activity.first.id}" }.to change(Signup, :count).by(-count)
+        expect { delete "/activities/#{Activity.second.id}" }.to change(Signup, :count).by(-count)
       end
 
     end


### PR DESCRIPTION

Test for DELETE /activities/:id was expecting 2 associated signups to be deleted, but was deleting an activity with only 1 assoc signup.
README was indicating different JSON formatting in the responses from campers#index and campers#show, even though they use the same serializer.